### PR TITLE
Added tcsh completion

### DIFF
--- a/completions/tmatrix-completion.tcsh
+++ b/completions/tmatrix-completion.tcsh
@@ -1,0 +1,60 @@
+# Copyright (C) 2018-2019 Miloš Stojanović
+#
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# To use this completion script:
+#    1) Copy this file to ${HOME}:
+#        cp tmatrix-completion.tcsh ~/.tmatrix-completion.tcsh
+#    2) Add the following line to your .tcshrc/.cshrc:
+#        source ~/.tmatrix-completion.tcsh
+
+set tmatrix_short_options = (\
+	-s \
+	-f \
+	-G \
+	-l \
+	-r \
+	-C \
+	-c \
+	-t \
+)
+
+set tmatrix_long_options = (\
+	--mode \
+	--steps-per-sec \
+	--fall-speed \
+	--start-gap \
+	--gap \
+	--color \
+	--background \
+	--title \
+)
+
+set tmatrix_modes = ( default dense )
+
+set tmatrix_colors = (\
+	default \
+	white \
+	gray \
+	black \
+	red \
+	green \
+	yellow \
+	blue \
+	magenta \
+	cyan \
+)
+
+complete tmatrix \
+	'n/-c/$tmatrix_colors/' \
+	'n/-C/$tmatrix_colors/' \
+	'c/--color=/$tmatrix_colors/' \
+	'c/--background=/$tmatrix_colors/' \
+	'c/--mode=/$tmatrix_modes/' \
+	'n/--help/n/' \
+	'n/--version/n/' \
+	'C/--h/(--help)/' \
+	'C/--v/(--version)/' \
+	'C/--/$tmatrix_long_options/=/' \
+	'C/-/$tmatrix_short_options/' \
+	'p/*/n/' # don't complete file names and alike


### PR DESCRIPTION
- [X] short options (`-l`, `-r`, ...)
- [X] long options with parameters (`--mode=`, `--steps-per-sec=`, ...)
- [X] long options without parameters (`--help`, `--version`)
- [X] mode name completion (`default`, `dense`) for `--mode=`
- [X] color name completion for short options (`-c`, `-C`)
- [X] color name completion for long options (`--background`, `--color`)
- [X] completion stops after `--help` and `--version`
- [X] completion doesn't complete anything besides options (like filenames)
- [X] comment guiding on manual installation

I'm not well-versed in `tcsh`, but this should suffice for now. If somebody with an experience in `tcsh` completions, it can be changed later.

Related to #5.