### PR TITLE
Added .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = tab
+tab_width = 8


### PR DESCRIPTION
When working on #17, I (again) used spaces instead of tabs as the project tries to.

[EditorConfig](http://EditorConfig.org) is a tool aimed at standardising simple formatting rules for software projects. Here is an `.editorconfig` file that has sensible defaults and uses tabs for completions, C++ source files and `CMakeLists.txt`.